### PR TITLE
Popup changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config.php
 testing.php
 odok-setup\[noMuniorCounty\].sql
 /site/OpenLayers-2.8/
+/nbproject/private/
+/nbproject/

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -94,7 +94,7 @@ header.navbox nav a.search{
 }
 ul{
     list-style:none outside none;
-    padding-left: 0;
+    padding-left: 20px;
 }
 li:nth-child(2){
     padding-bottom: 6px;
@@ -112,7 +112,8 @@ li:nth-child(2){
     max-width:48px;
     float:left;
     clear:left;
-    padding:.5em;
+    padding:.2em;
+    margin-left: -7px;
 }
 footer{
     position:absolute;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -93,7 +93,11 @@ header.navbox nav a.search{
     background:url(../images/search.svg) top left no-repeat
 }
 ul{
-    list-style:disc outside none;
+    list-style:none outside none;
+    padding-left: 0px;
+}
+li:nth-child(2){
+    padding-bottom: 6px;
 }
 .thumb{
     max-height:100px;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -93,7 +93,7 @@ header.navbox nav a.search{
     background:url(../images/search.svg) top left no-repeat
 }
 ul{
-    list-style:disc outside none;
+    list-style:none outside none;
     padding-left: 0;
 }
 .thumb{

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -97,7 +97,7 @@ ul{
     padding-left: 20px;
 }
 li:nth-child(2){
-    padding-bottom: 6px;
+    padding-bottom: 8px;
 }
 .thumb{
     max-height:100px;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -93,11 +93,7 @@ header.navbox nav a.search{
     background:url(../images/search.svg) top left no-repeat
 }
 ul{
-    list-style:none outside none;
-    padding-left: 0px;
-}
-li:nth-child(2){
-    padding-bottom: 6px;
+    list-style:disc outside none;
 }
 .thumb{
     max-height:100px;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -92,19 +92,41 @@ header.navbox nav a.search{
     height:33px;
     background:url(../images/search.svg) top left no-repeat
 }
+.leaflet-popup-content-wrapper{
+    background: rgba(255, 255, 255, 0.87) !important;    
+}
 ul{
     list-style:none outside none;
     padding-left: 20px;
+    margin-bottom: 0px;
+}
+li:first-child{
+        font-size: 1.2em;
+        line-height: 1;
+        padding: 5px 0px 4px 2px;
 }
 li:nth-child(2){
-    padding-bottom: 8px;
+    padding-bottom: 10px;
+    font-size: 1.2em;
+    line-height: 1;
+    padding-left: 2px;
+}
+li:nth-child(3){
+        line-height: 1.1;
+        font-size: 1.1em;
+        padding-left: 2px;
+        margin-left: -22px;
+}
+li:nth-child(4){
+    padding: 14px 2px 4px 2px;
+    margin-left: -22px;
 }
 .thumb{
-    max-height:100px;
+    max-height:160px;
     max-width:100px;
     float:right;
     clear:right;
-    padding:5px;
+    padding: 6px 2px 4px 10px;
 }
 .edit{
     width: 5%;
@@ -113,7 +135,8 @@ li:nth-child(2){
     float:left;
     clear:left;
     padding:.2em;
-    margin-left: -7px;
+    margin-left: -5px;
+    margin-top: 4px;
 }
 footer{
     position:absolute;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -96,6 +96,9 @@ ul{
     list-style:none outside none;
     padding-left: 0;
 }
+li:nth-child(2){
+    padding-bottom: 6px;
+}
 .thumb{
     max-height:100px;
     max-width:100px;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -100,24 +100,24 @@ ul{
     padding-left: 20px;
     margin-bottom: 0px;
 }
-li:first-child{
+.leaflet-popup-content li:first-child{
         font-size: 1.2em;
         line-height: 1;
         padding: 5px 0px 4px 2px;
 }
-li:nth-child(2){
+.leaflet-popup-content li:nth-child(2){
     padding-bottom: 10px;
     font-size: 1.2em;
     line-height: 1;
     padding-left: 2px;
 }
-li:nth-child(3){
+.leaflet-popup-content li:nth-child(3){
         line-height: 1.1;
         font-size: 1.1em;
         padding-left: 2px;
         margin-left: -22px;
 }
-li:nth-child(4){
+.leaflet-popup-content li:nth-child(4){
     padding: 14px 2px 4px 2px;
     margin-left: -22px;
 }

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -94,6 +94,7 @@ header.navbox nav a.search{
 }
 ul{
     list-style:disc outside none;
+    padding-left: 0;
 }
 .thumb{
     max-height:100px;

--- a/site/css/my.css
+++ b/site/css/my.css
@@ -98,7 +98,9 @@ header.navbox nav a.search{
 ul{
     list-style:none outside none;
     padding-left: 20px;
-    margin-bottom: 0px;
+}
+.leaflet-popup-content ul{
+     margin-bottom: 0px;
 }
 .leaflet-popup-content li:first-child{
         font-size: 1.2em;
@@ -122,7 +124,7 @@ ul{
     margin-left: -22px;
 }
 .thumb{
-    max-height:160px;
+    max-height:100px;
     max-width:100px;
     float:right;
     clear:right;

--- a/site/map.js
+++ b/site/map.js
@@ -128,6 +128,16 @@ $(document).ready(function() {
             .openOn(map);
     }
     map.on('contextmenu', onMapClick);
+    
+    // center popup AND marker to the map + 23% of clientHeight
+    // to position it under the leaflet-control-locate icon on small displays
+    if ($(window).width() <= 800){
+        map.on('popupopen', function(e) {
+        var px = map.project(e.popup._latlng); // find the pixel location on the map where the popup anchor is
+        px.y -= e.popup._container.clientHeight/2+e.popup._container.clientHeight*0.23; // find the height of the popup container, divide by 2, subtract from the Y axis of marker location
+        map.panTo(map.unproject(px),{animate: true}); // pan to new center
+        });
+    }
 });
 
 // create the popupcontents
@@ -135,7 +145,7 @@ function makePopup(feature) {
     // Based on https://stackoverflow.com/questions/10889954
     var properties = feature.properties;
     var desc = "";
-
+    
     // code originally from updateFeatures.py
     // list-link
     if (properties.descriptions.list) {
@@ -154,7 +164,7 @@ function makePopup(feature) {
             showImage = properties.image.replace(/\s/g, '_');
         }
         desc += '<a href="http://commons.wikimedia.org/wiki/File:' + showImage + '" target="_blank">';
-        desc += '<img src="https://commons.wikimedia.org/w/thumb.php?f=' + showImage + '&width=100" class="thumb" />';
+        desc += '<img src="https://commons.wikimedia.org/w/thumb.php?f=' + showImage + '&width=160" class="thumb" />';
         desc += '</a>';
 
         // info
@@ -203,12 +213,9 @@ function makePopup(feature) {
     if (properties.spatial.address) {
         desc += ' - ' + properties.spatial.address;
     }
-    desc += '</li></ul>';
 
     // description
-    if (properties.image || properties.descriptions.wikidata || properties.descriptions.descr) {
-        desc += '<br clear="both"/>';
-    }
+    desc += '</li><li> ';
     if (properties.descriptions.wikidata) {
         desc += properties.descriptions.ingress;
         desc += '  <a href="https://www.wikidata.org/wiki/Special:GoToLinkedPage/svwiki/' + properties.descriptions.wikidata + '" target="_blank">';
@@ -218,7 +225,11 @@ function makePopup(feature) {
     else if (properties.descriptions.descr) {
         desc += properties.descriptions.descr;
     }
-
+    
+      if (properties.image || properties.descriptions.wikidata || properties.descriptions.descr) {
+        desc += '<br clear="both"/>';
+    }
+    desc += '</li></ul>';
     return desc;
 
 }

--- a/site/map.js
+++ b/site/map.js
@@ -128,10 +128,10 @@ $(document).ready(function() {
             .openOn(map);
     }
     map.on('contextmenu', onMapClick);
-    
+
     // center popup AND marker to the map + 23% of clientHeight
     // to position it under the leaflet-control-locate icon on small displays
-    if ($(window).width() <= 800){
+    if ($(window).width() <= 380){
         map.on('popupopen', function(e) {
         var px = map.project(e.popup._latlng); // find the pixel location on the map where the popup anchor is
         px.y -= e.popup._container.clientHeight/2+e.popup._container.clientHeight*0.23; // find the height of the popup container, divide by 2, subtract from the Y axis of marker location
@@ -145,7 +145,7 @@ function makePopup(feature) {
     // Based on https://stackoverflow.com/questions/10889954
     var properties = feature.properties;
     var desc = "";
-    
+
     // code originally from updateFeatures.py
     // list-link
     if (properties.descriptions.list) {
@@ -164,7 +164,7 @@ function makePopup(feature) {
             showImage = properties.image.replace(/\s/g, '_');
         }
         desc += '<a href="http://commons.wikimedia.org/wiki/File:' + showImage + '" target="_blank">';
-        desc += '<img src="https://commons.wikimedia.org/w/thumb.php?f=' + showImage + '&width=160" class="thumb" />';
+        desc += '<img src="https://commons.wikimedia.org/w/thumb.php?f=' + showImage + '&width=100" class="thumb" />';
         desc += '</a>';
 
         // info
@@ -225,8 +225,8 @@ function makePopup(feature) {
     else if (properties.descriptions.descr) {
         desc += properties.descriptions.descr;
     }
-    
-      if (properties.image || properties.descriptions.wikidata || properties.descriptions.descr) {
+
+    if (properties.image || properties.descriptions.wikidata || properties.descriptions.descr) {
         desc += '<br clear="both"/>';
     }
     desc += '</li></ul>';


### PR DESCRIPTION
In my.css: adds 13% transparency to popup-content-wrapper (for airy and
integrated feeling), adds 2px padding to popup elements (to center the
popup content and move the thumbnail further from [x] button), grows
thumbnail vertically by setting its max-height from 100px to 160px (for
a better view of the image), aligns location's text(li:nth-child(3)) on
left (to gain more space for the text).
In map.js: centers popup AND marker to the map + 23% of clientHeight (to
position it under the leaflet-control-locate icon on small
displays(<=800)), grows thumbnail horizontally by setting its max-width
from 100px to 160px (for a better view of the image), puts the description in the same `<ul>` with title, artist, location and moves `<br clear="both"/>` to the end of the function to allow wrapping along the thumbnail (to integrate description's text in the text flow and the whole layout).