### PR TITLE
minor translation

### DIFF
--- a/site/search.html
+++ b/site/search.html
@@ -34,7 +34,7 @@
       <div id="sidebar">
         <div class="pure-form" id="searchheader">
           <fieldset style="padding-bottom: 2px;">
-            <legend class="logo"><a href="index.html"><img src="images/Offentligkonst_logo_nav.svg" alt="logo" /></a>&nbsp; &ndash; The search engine</legend>
+            <legend class="logo"><a href="index.html"><img src="images/Offentligkonst_logo_nav.svg" alt="logo" /></a>&nbsp; &ndash; Sökmotorn</legend>
             <div style="width: 99%;display: inline-block; float:right">
                 <label for="coord_input">&nbsp;med Koordinater</label>
                 <input id="coord_input" type="checkbox" value="coord" name="ci" title="Require coordinate" tabindex=1/>


### PR DESCRIPTION
If the translated string of some reason should actually be in English, an local `lang` attribute would be needed instead of this change.