### PR TITLE
Update tile server url pattern

### DIFF
--- a/site/map.js
+++ b/site/map.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
     // map.addLayer(osmSE);
 
     // settings for OSM
-    var osm = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    var osm = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
         attribution: attribution + 'Kartdata © <a href="https://openstreetmap.org">OpenStreetMap</a>-bidragsgivare',
         maxZoom: 19,
     });

--- a/site/search.js
+++ b/site/search.js
@@ -368,7 +368,7 @@ window.onload = function load() {
     // map.addLayer(osmSE);
 
     // settings for OSM
-    var osm = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    var osm = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
         attribution: 'Kartdata © <a href="https://openstreetmap.org">OpenStreetMap</a>-bidragsgivare',
         maxZoom: 19,
     });


### PR DESCRIPTION
Tile server url pattern has changed per openstreetmap/operations#737

openstreetmap.se url left unchanged since that is down.